### PR TITLE
Add support for PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       dist: bionic
     - php: nightly
       dist: bionic
-      env: COMPOSER_OPTS="--ignore-platform-reqs"
+      env: COMPOSER_OPTS="--ignore-platform-req=php"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
       env: PHPUNIT_LEGACY="true"
     - php: 7.3
       dist: bionic
+      env: PHPUNIT_LEGACY="true"
     - php: 7.4
       dist: bionic
     - php: nightly
@@ -22,6 +23,18 @@ cache:
 
 install:
   - travis_retry composer install $COMPOSER_OPTS
+
+  # Where PHPUnit v8 is used, we need to replace the config.
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]
+    && [ ${TRAVIS_PHP_VERSION:2:1} -lt 4 ]; then
+      mv -v tests/phpunit.legacy.xml tests/phpunit.xml
+    ; fi
+
+  # PHPUnit 9 supports 7.3, but Infection PHP 18 can't read
+  # its config so instead we downgrade to PHPUnit 8.5 here.
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.3" ]]; then
+      travis_retry composer require -W phpunit/phpunit:^8.5
+    ; fi
 
 script:
   - vendor/bin/grumphp run

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ matrix:
     - php: nightly
       dist: bionic
       env: COMPOSER_OPTS="--ignore-platform-reqs"
-  allow_failures:
-    - php: nightly
-      env: COMPOSER_OPTS="--ignore-platform-reqs"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   # Where PHPUnit v8 is used, we need to replace the config.
   - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]
     && [ ${TRAVIS_PHP_VERSION:2:1} -lt 4 ]; then
-      mv -v tests/phpunit.legacy.xml tests/phpunit.xml
+      cp -v tests/phpunit.legacy.xml tests/phpunit.xml
     ; fi
 
   # PHPUnit 9 supports 7.3, but Infection PHP 18 can't read
@@ -38,11 +38,7 @@ install:
 
 script:
   - vendor/bin/grumphp run
-
-  - if [[ -z "$PHPUNIT_LEGACY" ]]; then composer test; else
-      vendor/bin/phpunit --testdox --color=always
-        --configuration tests/phpunit.legacy.xml
-    ; fi
+  - composer test
 
   - if [[ -z "$PHPUNIT_LEGACY" ]]; then composer infection; else
       vendor/bin/infection --ansi --threads=4 --coverage=tests/test-results

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,11 @@ matrix:
   include:
     - php: 7.2
       dist: bionic
-      env: COMPOSER_OPTS=""
+      env: PHPUNIT_LEGACY="true"
     - php: 7.3
       dist: bionic
-      env: COMPOSER_OPTS=""
     - php: 7.4
       dist: bionic
-      env: COMPOSER_OPTS=""
     - php: nightly
       dist: bionic
       env: COMPOSER_OPTS="--ignore-platform-reqs"
@@ -27,8 +25,18 @@ install:
 
 script:
   - vendor/bin/grumphp run
-  - composer test
-  - composer infection
+
+  - if [[ -z "$PHPUNIT_LEGACY" ]]; then composer test; else
+      vendor/bin/phpunit --testdox --color=always
+        --configuration tests/phpunit.legacy.xml
+    ; fi
+
+  - if [[ -z "$PHPUNIT_LEGACY" ]]; then composer infection; else
+      vendor/bin/infection --ansi --threads=4 --coverage=tests/test-results
+        --test-framework-options="-c tests/phpunit.legacy.xml"
+        --only-covered --min-msi=100 --min-covered-msi=100
+    ; fi
+
   - composer psalm
 
 after_success: bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ matrix:
   include:
     - php: 7.2
       dist: bionic
-      env: PHPUNIT_LEGACY="true"
     - php: 7.3
       dist: bionic
-      env: PHPUNIT_LEGACY="true"
     - php: 7.4
       dist: bionic
     - php: nightly
@@ -40,9 +38,9 @@ script:
   - vendor/bin/grumphp run
   - composer test
 
-  - if [[ -z "$PHPUNIT_LEGACY" ]]; then composer infection; else
-      vendor/bin/infection --ansi --threads=4 --coverage=tests/test-results
-        --test-framework-options="-c tests/phpunit.legacy.xml"
+  - if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then composer infection; else
+      vendor/bin/infection --ansi --threads=4
+        --initial-tests-php-options="-d xdebug.mode=coverage"
         --only-covered --min-msi=100 --min-covered-msi=100
     ; fi
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",
-        "vimeo/psalm": "^3.11",
+        "vimeo/psalm": "^4.1",
         "infection/infection": "^0.19.2",
         "spatie/phpunit-watcher": "^1.22",
         "phpunit/php-invoker": "^3.1",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "infection/infection": "^0.15.3",
         "spatie/phpunit-watcher": "^1.22",
         "phpunit/php-invoker": "^2.0",
-        "pluswerk/grumphp-config": "^3.0"
+        "pluswerk/grumphp-config": "^4.0"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
         "process-timeout": 0
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4",
+        "phpunit/phpunit": "^8.5 || ^9.4",
         "vimeo/psalm": "^4.1",
-        "infection/infection": "^0.19.2",
+        "infection/infection": "^0.15.3 || ^0.18.2 || ^0.19.2",
         "spatie/phpunit-watcher": "^1.22",
-        "phpunit/php-invoker": "^3.1",
+        "phpunit/php-invoker": "^2.0 || ^3.1",
         "pluswerk/grumphp-config": "^4.0"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.4",
         "vimeo/psalm": "^4.1",
-        "infection/infection": "^0.15.3 || ^0.18.2 || ^0.19.2",
-        "spatie/phpunit-watcher": "^1.22",
+        "infection/infection": "^0.15.3 || ^0.18.2 || ^0.20.1",
+        "spatie/phpunit-watcher": "^1.24 || dev-master#071fbbf",
         "phpunit/php-invoker": "^2.0 || ^3.1",
-        "pluswerk/grumphp-config": "^4.0"
+        "pluswerk/grumphp-config": "^4.0.1"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
         "process-timeout": 0
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^9.4",
         "vimeo/psalm": "^3.11",
-        "infection/infection": "^0.15.3",
+        "infection/infection": "^0.19.2",
         "spatie/phpunit-watcher": "^1.22",
-        "phpunit/php-invoker": "^2.0",
+        "phpunit/php-invoker": "^3.1",
         "pluswerk/grumphp-config": "^4.0"
     },
     "license": "MIT",

--- a/src/Conditional/BasicExpression.php
+++ b/src/Conditional/BasicExpression.php
@@ -17,7 +17,7 @@ abstract class BasicExpression implements ShellInterface
      * This is not POSIX-compatible (only eg. Korn and Bash), beware before using it
      * @var bool
      */
-    protected $bashEnhancedBrackets;
+    protected $bashEnhancedBrackets = false;
     /** @var bool this is always double quoted */
     protected $escapedValue = false;
     /** @var bool */

--- a/src/Literal/ShellWord.php
+++ b/src/Literal/ShellWord.php
@@ -64,9 +64,9 @@ class ShellWord implements ShellInterface
     /** @var string */
     protected $delimiter = ' ';
     /** @var string */
-    protected $argument;
+    protected $argument = '';
     /** @var string|ShellInterface */
-    protected $value;
+    protected $value = '';
 
     /**
      * The constructor is protected, you must choose one of the children

--- a/tests/Collection/CollectionTupleTest.php
+++ b/tests/Collection/CollectionTupleTest.php
@@ -45,6 +45,13 @@ final class CollectionTupleTest extends TestCase
         $this->assertEquals(['||', 'a'], $tuple->__toArray());
     }
 
+    public function testToArrayWithBuilder(): void
+    {
+        $builder = ShellBuilder::command('echo')->addArgument('hunter1');
+        $tuple = CollectionTuple::create($builder, ControlOperator::AND_OPERATOR);
+        $this->assertEquals(['&&', $builder->__toArray()], $tuple->__toArray());
+    }
+
     public function testWithoutCreatingTuple(): void
     {
         $tuple = new Pipeline();

--- a/tests/ShellBuilderTest.php
+++ b/tests/ShellBuilderTest.php
@@ -756,7 +756,7 @@ final class ShellBuilderTest extends TestCase
 
     public function testComplexCondiditionalArgumentsWithWrongArguments(): void
     {
-        self::expectException(\ErrorException::class);
+        self::expectException(\AssertionError::class);
         ShellBuilder::new()
             ->ifThis(static function (ShellBuilder $builder) {
                 return 'world';
@@ -769,7 +769,7 @@ final class ShellBuilderTest extends TestCase
 
     public function testCondiditionalArgumentsWithWrongArguments(): void
     {
-        self::expectException(\ErrorException::class);
+        self::expectException(\AssertionError::class);
         ShellBuilder::new()
             ->if(
                 true,

--- a/tests/phpunit-bootstrap.php
+++ b/tests/phpunit-bootstrap.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 error_reporting(E_ALL);
+ini_set('assert.exception', '1');
 ini_set('display_errors', '1');
 
 // Currently phpunit's default error handling doesn't properly catch warnings / errors from data providers

--- a/tests/phpunit.legacy.xml
+++ b/tests/phpunit.legacy.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+        bootstrap="phpunit-bootstrap.php"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        beStrictAboutCoversAnnotation="true"
+        beStrictAboutOutputDuringTests="true"
+        beStrictAboutChangesToGlobalState="true"
+        enforceTimeLimit="true"
+        executionOrder="default"
+        resolveDependencies="true"
+        timeoutForLargeTests="1"
+        timeoutForMediumTests="1"
+        timeoutForSmallTests="1"
+        colors="true">
+    <testsuites>
+        <testsuite name="All">
+            <directory suffix="Test.php">../tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">../src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-html" target="test-results/report" lowUpperBound="49" highLowerBound="89"/>
+        <log type="coverage-clover" target="test-results/coverage.xml"/>
+        <log type="coverage-text" target="test-results/report.txt" showUncoveredFiles="false"/>
+        <log type="junit" target="test-results/logfile.xml"/>
+        <log type="testdox-html" target="test-results/testdox.html"/>
+        <log type="testdox-text" target="test-results/testdox.txt"/>
+    </logging>
+</phpunit>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         bootstrap="phpunit-bootstrap.php"
         convertErrorsToExceptions="true"
         convertNoticesToExceptions="true"
@@ -14,23 +14,26 @@
         timeoutForLargeTests="1"
         timeoutForMediumTests="1"
         timeoutForSmallTests="1"
-        colors="true">
+        colors="true"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">../src/</directory>
+        </include>
+        <report>
+            <clover outputFile="test-results/coverage.xml"/>
+            <html outputDirectory="test-results/report" lowUpperBound="49" highLowerBound="89"/>
+            <text outputFile="test-results/report.txt" showUncoveredFiles="false"/>
+        </report>
+    </coverage>
     <testsuites>
         <testsuite name="All">
             <directory suffix="Test.php">../tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">../src/</directory>
-        </whitelist>
-    </filter>
     <logging>
-        <log type="coverage-html" target="test-results/report" lowUpperBound="49" highLowerBound="89"/>
-        <log type="coverage-clover" target="test-results/coverage.xml"/>
-        <log type="coverage-text" target="test-results/report.txt" showUncoveredFiles="false"/>
-        <log type="junit" target="test-results/logfile.xml"/>
-        <log type="testdox-html" target="test-results/testdox.html"/>
-        <log type="testdox-text" target="test-results/testdox.txt"/>
+        <junit outputFile="test-results/logfile.xml"/>
+        <testdoxHtml outputFile="test-results/testdox.html"/>
+        <testdoxText outputFile="test-results/testdox.txt"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
## Description and Background

With the recent changes in ChrisB9/php8-xdebug that fix xdebug options, update composer and (afaict) remove the profiler that caused errors previously, there seem to be only two errors remaining in the tests on PHP 8.

Both errors are with the `assert()` lines, which throw an `AssertionError` in v8, but only trigger a warning (converted to `ErrorException`) when ran under v7. This is caused by a change in php8 which now enables the `assert.exception` option by default.

I considered a couple methods, but simply enabling the option by default seems to be the cleanest route. The option itself was added in v7, so this change just makes things consistent across both versions.

## How Has This Been Tested
Existing tests fixed, ran with `docker-compose run php composer test && docker-compose run php8 composer test`.

Psalm is happy, but the infection tests are currently still failing as a result of xdebug connection issues.

#### Checklist

- [x] My code follows the PSR coding guideline.
- [x] I have updated the `documentation` accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added `tests` to cover my changes.
- [x] All new and existing tests passed.

Resolves #15 